### PR TITLE
Refactor dashboard, budget evaluation, and categorization

### DIFF
--- a/src/budget/budget_manager.py
+++ b/src/budget/budget_manager.py
@@ -50,12 +50,9 @@ def save_budget(budget: Budget):
 
 def read_budget(budget_name: str):
     with open(f"{BUDGET_PATH}{budget_name}.yaml", "r") as f:
-        budget = Budget(**yaml.safe_load(f))
-        budget_items = []
-        for item in budget.items:
-            budget_items.append(BudgetItem(item.categories, item.budgeted_amount))
-        budget.items = budget_items
-
+        _data = yaml.safe_load(f)
+        budget = Budget(**_data)
+        budget.items = [BudgetItem(**item) for item in _data.get("items", [])]
         return budget
 
 

--- a/src/budget/budget_manager.py
+++ b/src/budget/budget_manager.py
@@ -33,7 +33,7 @@ class BudgetItem:
     budgeted_amount: float
 
 
-def write_budget(budget: Budget, filename: str = None):
+def write_budget(budget: Budget, filename: str | None = None):
     if filename is None:
         filename = budget.name
     with open(f"{BUDGET_PATH}{filename}.yaml", "w") as f:
@@ -53,7 +53,7 @@ def read_budget(budget_name: str):
         budget = Budget(**yaml.safe_load(f))
         budget_items = []
         for item in budget.items:
-            budget_items.append(BudgetItem(**item))
+            budget_items.append(BudgetItem(item.categories, item.budgeted_amount))
         budget.items = budget_items
 
         return budget

--- a/src/budget/plot.py
+++ b/src/budget/plot.py
@@ -75,8 +75,7 @@ app.layout = html.Div(
             options=[
                 {"label": cat, "value": cat}
                 for cat in transactions_df["category"].dropna().unique()
-            ]
-            + [{"label": "All", "value": "All"}],
+            ],
             value=None,
             clearable=True,
             multi=True,
@@ -159,7 +158,7 @@ def update_chart(selected_month, num_months, selected_category):
         color_discrete_map={"total_in": "green", "total_out": "red"},
     )
 
-    ### Budget vs Actuals ###
+    # --- Budget vs Actuals ---
     budget = read_budget("Student")
     logger.info(f"Budget: {budget}")
 
@@ -187,8 +186,8 @@ def update_chart(selected_month, num_months, selected_category):
 
     start_month = str(pd.Period(selected_month, freq="M") - (num_months - 1))
 
-    # line plot for previous 6 months
-    if selected_category and "All" not in selected_category:
+    # --- Budget vs Actuals ---
+    if selected_category:
         if isinstance(selected_category, str):
             selected_category = [selected_category]
 

--- a/src/budget/plot.py
+++ b/src/budget/plot.py
@@ -35,6 +35,8 @@ all_months = pd.period_range(
     start=transactions_df["month"].min(), end=transactions_df["month"].max(), freq="M"
 ).astype(str)
 
+all_categories = transactions_df["category"].dropna().unique()
+
 # --- Dash App ---
 app = dash.Dash(__name__)
 
@@ -69,10 +71,7 @@ app.layout = html.Div(
             id="category-dropdown",
             options=[
                 {"label": "All", "value": "All"},
-                *(
-                    {"label": str(cat), "value": str(cat)}
-                    for cat in transactions_df["category"].dropna().unique()
-                ),
+                *({"label": str(cat), "value": str(cat)} for cat in all_categories),
             ],
             value="All",
             clearable=True,
@@ -292,15 +291,16 @@ def update_chart(selected_month, num_months, selected_category):
 
     # --- Monthly Summary Table ---
 
-    transactions = transactions_df[transactions_df["month"] == selected_month]
+    monthly_transactions = transactions_df[
+        transactions_df["month"] == selected_month
+    ].copy()
     # Format columns for display
-    transactions_display = transactions.copy()
-    transactions_display["date"] = pd.to_datetime(
-        transactions_display["date"]
+
+    monthly_transactions["date"] = pd.to_datetime(
+        monthly_transactions["date"]
     ).dt.strftime("%Y-%m-%d")
 
     # Table
-
     table = dash_table.DataTable(
         columns=[
             {"name": "Date", "id": "date"},
@@ -309,7 +309,7 @@ def update_chart(selected_month, num_months, selected_category):
             {"name": "Money In", "id": "money_in"},
             {"name": "Money Out", "id": "money_out"},
         ],
-        data=transactions_display.to_dict("records"),
+        data=monthly_transactions.to_dict("records"),
         style_table={"overflowX": "auto"},
         style_cell={"textAlign": "left"},
         sort_action="native",

--- a/src/budget/plot.py
+++ b/src/budget/plot.py
@@ -63,7 +63,7 @@ app.layout = html.Div(
         dcc.Graph(id="monthly-budget-chart"),
         dcc.Dropdown(
             id="num-months-dropdown",
-            options=[{"label": m, "value": m} for m in range(1, 64)],
+            options=[{"label": m, "value": m} for m in range(1, len(all_months) + 1)],
             value=6,
             clearable=False,
         ),

--- a/src/budget/plot.py
+++ b/src/budget/plot.py
@@ -15,6 +15,9 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(filename)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+# -- Data Preparation --
+
 # Read the transactions CSV
 transactions_df = pd.read_csv("src/budget/data/transactions.csv")
 transactions_df["date"] = pd.to_datetime(transactions_df["date"])
@@ -36,15 +39,6 @@ monthly_summary = (
     .reset_index()
 )
 
-# Aggregate by category and month for line plot
-category_monthly = (
-    transactions_df.groupby(["month", "category"])
-    .agg(
-        total_in=pd.NamedAgg(column="money_in", aggfunc="sum"),
-        total_out=pd.NamedAgg(column="money_out", aggfunc="sum"),
-    )
-    .reset_index()
-)
 
 # --- Dash App ---
 app = dash.Dash(__name__)
@@ -107,6 +101,17 @@ app.layout = html.Div(
     Input("category-dropdown", "value"),
 )
 def update_chart(selected_month, num_months, selected_category):
+
+    # Aggregate by category and month for line plot
+    category_monthly = (
+        transactions_df.groupby(["month", "category"])
+        .agg(
+            total_in=pd.NamedAgg(column="money_in", aggfunc="sum"),
+            total_out=pd.NamedAgg(column="money_out", aggfunc="sum"),
+        )
+        .reset_index()
+    )
+
     # Filter for selected month
     filtered_overall = monthly_summary[monthly_summary["month"] == selected_month]
     filtered_with_category = category_monthly[


### PR DESCRIPTION
## Summary

- **Extracted `evaluate_budget()` into `budget_manager.py`** — budget vs. actuals logic was inlined in the Dash callback; it now lives as a standalone function, keeping `plot.py` focused on rendering
- **Refactored line chart to remove conditional branching** — the `if selected_category and "All" not in selected_category` split is gone; the chart now uses a single code path, treating `"All"` as an aggregate category
- **Moved global aggregations into the callback** — `monthly_summary` and `category_monthly` are now computed inside `update_chart()` so all filtering is reactive
- **Dropdown improvements** — month dropdown uses a continuous `pd.period_range` to fill month gaps; timeframe dropdown is bounded to available months; category dropdown defaults to `"All"`
- **`clean.py` REMOVE support** — typing `REMOVE` during interactive categorization creates a `keep=False` rule to strip matching transactions
- **Fixed CSV filename** — `checking.csv` → `chequing.csv`
- **Minor cleanup** — simplified `read_budget()` with a list comprehension, updated type hints to `X | None` syntax

## Test plan
- [x] Launch dashboard with `python src/budget/plot.py` and verify all 6 charts render for the default month
- [x] Change month, timeframe, and category dropdowns and confirm all charts update correctly
- [x] Select `"All"` in the category dropdown and verify the line chart shows aggregate totals
- [x] Run `python src/budget/clean.py` and verify `REMOVE` input creates a removal rule
- [x] Verify budget vs. actuals chart still matches previous output

🤖 Generated with [Claude Code](https://claude.com/claude-code)